### PR TITLE
fix: elements UI clipping on mobile screens

### DIFF
--- a/components/ElementsContainer.tsx
+++ b/components/ElementsContainer.tsx
@@ -38,6 +38,7 @@ export function ElementsContainer({ isOpen, setIsOpen }: Props) {
           isOpen={isOpen}
           title="Get STARS"
           setIsOpen={setIsOpen}
+          className="max-w-[95vw]"
           defaultValues={{
             destinationChainId: "stargaze-1",
             destinationAsset: "ustars",


### PR DESCRIPTION
Elements is natively not fully responsive yet.
Before:
![image](https://github.com/iqlusioninc/celestine-sloths/assets/112631127/d423dbb9-4ace-472c-b25d-9515ce890947)
After:
![image](https://github.com/iqlusioninc/celestine-sloths/assets/112631127/47983d8b-3ba1-4130-8c0e-e72e1488f007)

**Note:** Chain and Token selection modal does not have this issue. Only Input Modal had this issue.